### PR TITLE
Hotfix PUT request without content-length

### DIFF
--- a/wsgidav/request_server.py
+++ b/wsgidav/request_server.py
@@ -803,7 +803,7 @@ class RequestServer:
             # HOTFIX: not fully understood, but MS sends PUT without content-length,
             # when creating new files
             agent = environ.get("HTTP_USER_AGENT", "")
-            if "Microsoft-WebDAV-MiniRedir" in agent or "gvfs/" in agent:  # issue #10
+            if "Microsoft-WebDAV-MiniRedir" in agent or "gvfs/" in agent or "Darwin" in agent:  # issue #10
                 _logger.warning(
                     "Setting misssing Content-Length to 0 for MS / gvfs client"
                 )


### PR DESCRIPTION
MacOS Ventura behaviour is now similar to MS Windows

PUT Response - Error - before patch:



```HTTP/2 411 Length Required
Server: nginx
Date: Sun, 09 Apr 2023 13:11:29 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 411
X-Powered-By: Phusion Passenger(R)
Status: 411 Length Required

<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>
<html><head>
  <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
  <title>411 Status</title>
</head><body>
  <h1>411 Status</h1>
  <p>411: PUT request with invalid Content-Length: (None)</p>
<hr/>
<a href='https://github.com/mar10/wsgidav/'>WsgiDAV/4.2.0</a> - 2023-04-09 15:11:29.311310
</body></html>
```

PUT Response after patch:


```HTTP/2 201 Created
Server: nginx
Date: Sun, 09 Apr 2023 13:52:04 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 372
X-Powered-By: Phusion Passenger(R)
Etag: "18615659-1681048324-0"
Status: 201 Created

<!DOCTYPE HTML PUBLIC '-//W3C//DTD HTML 4.01//EN' 'http://www.w3.org/TR/html4/strict.dtd'>
<html><head>
  <meta http-equiv='Content-Type' content='text/html; charset=utf-8'>
  <title>201 Created</title>
</head><body>
  <h1>201 Created</h1>
  <p>201 Created</p>
<hr/>
<a href='https://github.com/mar10/wsgidav/'>WsgiDAV/4.2.0</a> - 2023-04-09 15:52:04.162869
</body></html>
```
